### PR TITLE
Update the documentation to match the rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This gem automatically traces all requests made with Net::HTTP.
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'nethttp-instrumentation'
+gem 'signalfx-nethttp-instrumentation'
 ```
 
 And then execute:
@@ -20,7 +20,7 @@ And then execute:
 
 Or install it yourself as:
 
-    $ gem install nethttp-instrumentation
+    $ gem install signalfx-nethttp-instrumentation
 
 ## Usage
 


### PR DESCRIPTION
There seems to have been an omission to update the documentation when renaming the library. Please merge it if you like.